### PR TITLE
Adds the coverage level at the top of each locale and key report

### DIFF
--- a/lint/keys/action_attack.txt
+++ b/lint/keys/action_attack.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/action_brake.txt
+++ b/lint/keys/action_brake.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/action_break.txt
+++ b/lint/keys/action_break.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl

--- a/lint/keys/action_center_camera.txt
+++ b/lint/keys/action_center_camera.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/action_gas.txt
+++ b/lint/keys/action_gas.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/action_jump.txt
+++ b/lint/keys/action_jump.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/action_move_x.txt
+++ b/lint/keys/action_move_x.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/action_move_y.txt
+++ b/lint/keys/action_move_y.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/arcade_1_1.txt
+++ b/lint/keys/arcade_1_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_1_2.txt
+++ b/lint/keys/arcade_1_2.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_1_3.txt
+++ b/lint/keys/arcade_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/arcade_2_1.txt
+++ b/lint/keys/arcade_2_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_2_2.txt
+++ b/lint/keys/arcade_2_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/arcade_2_3.txt
+++ b/lint/keys/arcade_2_3.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_3_1.txt
+++ b/lint/keys/arcade_3_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_3_2.txt
+++ b/lint/keys/arcade_3_2.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_intro_1.txt
+++ b/lint/keys/arcade_intro_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/arcade_intro_2.txt
+++ b/lint/keys/arcade_intro_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/arcade_intro_3.txt
+++ b/lint/keys/arcade_intro_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/binding_alt_1.txt
+++ b/lint/keys/binding_alt_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/binding_alt_2.txt
+++ b/lint/keys/binding_alt_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/binding_axis.txt
+++ b/lint/keys/binding_axis.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/binding_button.txt
+++ b/lint/keys/binding_button.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/binding_negative.txt
+++ b/lint/keys/binding_negative.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/binding_positive.txt
+++ b/lint/keys/binding_positive.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/boss_guardian.txt
+++ b/lint/keys/boss_guardian.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/boss_queen.txt
+++ b/lint/keys/boss_queen.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/boss_rat.txt
+++ b/lint/keys/boss_rat.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/boss_turtle_golem.txt
+++ b/lint/keys/boss_turtle_golem.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/boss_yeti.txt
+++ b/lint/keys/boss_yeti.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/brother.txt
+++ b/lint/keys/brother.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/cage_help.txt
+++ b/lint/keys/cage_help.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/char_baaren.txt
+++ b/lint/keys/char_baaren.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_01.txt
+++ b/lint/keys/char_bear_01.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_02.txt
+++ b/lint/keys/char_bear_02.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_03.txt
+++ b/lint/keys/char_bear_03.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_04.txt
+++ b/lint/keys/char_bear_04.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_05.txt
+++ b/lint/keys/char_bear_05.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_06.txt
+++ b/lint/keys/char_bear_06.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_07.txt
+++ b/lint/keys/char_bear_07.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_08.txt
+++ b/lint/keys/char_bear_08.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_09.txt
+++ b/lint/keys/char_bear_09.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_10.txt
+++ b/lint/keys/char_bear_10.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_11.txt
+++ b/lint/keys/char_bear_11.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_12.txt
+++ b/lint/keys/char_bear_12.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_13.txt
+++ b/lint/keys/char_bear_13.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_14.txt
+++ b/lint/keys/char_bear_14.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_15.txt
+++ b/lint/keys/char_bear_15.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_16.txt
+++ b/lint/keys/char_bear_16.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_17.txt
+++ b/lint/keys/char_bear_17.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_18.txt
+++ b/lint/keys/char_bear_18.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_19.txt
+++ b/lint/keys/char_bear_19.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_20.txt
+++ b/lint/keys/char_bear_20.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_21.txt
+++ b/lint/keys/char_bear_21.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_22.txt
+++ b/lint/keys/char_bear_22.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_23.txt
+++ b/lint/keys/char_bear_23.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_24.txt
+++ b/lint/keys/char_bear_24.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_25.txt
+++ b/lint/keys/char_bear_25.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_26.txt
+++ b/lint/keys/char_bear_26.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_27.txt
+++ b/lint/keys/char_bear_27.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_28.txt
+++ b/lint/keys/char_bear_28.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_29.txt
+++ b/lint/keys/char_bear_29.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_30.txt
+++ b/lint/keys/char_bear_30.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_31.txt
+++ b/lint/keys/char_bear_31.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bear_32.txt
+++ b/lint/keys/char_bear_32.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_bee.txt
+++ b/lint/keys/char_bee.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/char_brother.txt
+++ b/lint/keys/char_brother.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/char_capitalos.txt
+++ b/lint/keys/char_capitalos.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_capitalus.txt
+++ b/lint/keys/char_capitalus.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_crocodile.txt
+++ b/lint/keys/char_crocodile.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have transparent translations:

--- a/lint/keys/char_crogo.txt
+++ b/lint/keys/char_crogo.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_fennec.txt
+++ b/lint/keys/char_fennec.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have transparent translations:

--- a/lint/keys/char_maybee.txt
+++ b/lint/keys/char_maybee.txt
@@ -1,4 +1,4 @@
-Translation coverage: 15.38%
+Translation coverage: 1 / 2 required (50.00%), 2 / 12 optional (16.67%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_mouse.txt
+++ b/lint/keys/char_mouse.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/char_penguin.txt
+++ b/lint/keys/char_penguin.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/char_queen.txt
+++ b/lint/keys/char_queen.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/char_reindeer.txt
+++ b/lint/keys/char_reindeer.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/char_scientist.txt
+++ b/lint/keys/char_scientist.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/char_shicka.txt
+++ b/lint/keys/char_shicka.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_sign.txt
+++ b/lint/keys/char_sign.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/char_tristopio.txt
+++ b/lint/keys/char_tristopio.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 1 / 2 required (50.00%), 1 / 12 optional (8.33%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/char_turtle.txt
+++ b/lint/keys/char_turtle.txt
@@ -1,3 +1,3 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv

--- a/lint/keys/cosmetic_001.txt
+++ b/lint/keys/cosmetic_001.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_002.txt
+++ b/lint/keys/cosmetic_002.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_003.txt
+++ b/lint/keys/cosmetic_003.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_004.txt
+++ b/lint/keys/cosmetic_004.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_005.txt
+++ b/lint/keys/cosmetic_005.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_006.txt
+++ b/lint/keys/cosmetic_006.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_007.txt
+++ b/lint/keys/cosmetic_007.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_008.txt
+++ b/lint/keys/cosmetic_008.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_009.txt
+++ b/lint/keys/cosmetic_009.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_010.txt
+++ b/lint/keys/cosmetic_010.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_011.txt
+++ b/lint/keys/cosmetic_011.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_012.txt
+++ b/lint/keys/cosmetic_012.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_013.txt
+++ b/lint/keys/cosmetic_013.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_014.txt
+++ b/lint/keys/cosmetic_014.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_015.txt
+++ b/lint/keys/cosmetic_015.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_016.txt
+++ b/lint/keys/cosmetic_016.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_017.txt
+++ b/lint/keys/cosmetic_017.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_018.txt
+++ b/lint/keys/cosmetic_018.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_019.txt
+++ b/lint/keys/cosmetic_019.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_020.txt
+++ b/lint/keys/cosmetic_020.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_021.txt
+++ b/lint/keys/cosmetic_021.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_022.txt
+++ b/lint/keys/cosmetic_022.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_023.txt
+++ b/lint/keys/cosmetic_023.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_024.txt
+++ b/lint/keys/cosmetic_024.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_025.txt
+++ b/lint/keys/cosmetic_025.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_026.txt
+++ b/lint/keys/cosmetic_026.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_027.txt
+++ b/lint/keys/cosmetic_027.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_028.txt
+++ b/lint/keys/cosmetic_028.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_029.txt
+++ b/lint/keys/cosmetic_029.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_030.txt
+++ b/lint/keys/cosmetic_030.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_031.txt
+++ b/lint/keys/cosmetic_031.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_032.txt
+++ b/lint/keys/cosmetic_032.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_033.txt
+++ b/lint/keys/cosmetic_033.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_034.txt
+++ b/lint/keys/cosmetic_034.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_035.txt
+++ b/lint/keys/cosmetic_035.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_036.txt
+++ b/lint/keys/cosmetic_036.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_037.txt
+++ b/lint/keys/cosmetic_037.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_038.txt
+++ b/lint/keys/cosmetic_038.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_039.txt
+++ b/lint/keys/cosmetic_039.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_040.txt
+++ b/lint/keys/cosmetic_040.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_041.txt
+++ b/lint/keys/cosmetic_041.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_042.txt
+++ b/lint/keys/cosmetic_042.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_043.txt
+++ b/lint/keys/cosmetic_043.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_044.txt
+++ b/lint/keys/cosmetic_044.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_045.txt
+++ b/lint/keys/cosmetic_045.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_046.txt
+++ b/lint/keys/cosmetic_046.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_047.txt
+++ b/lint/keys/cosmetic_047.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_048.txt
+++ b/lint/keys/cosmetic_048.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_049.txt
+++ b/lint/keys/cosmetic_049.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_050.txt
+++ b/lint/keys/cosmetic_050.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_051.txt
+++ b/lint/keys/cosmetic_051.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_052.txt
+++ b/lint/keys/cosmetic_052.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_053.txt
+++ b/lint/keys/cosmetic_053.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_054.txt
+++ b/lint/keys/cosmetic_054.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_055.txt
+++ b/lint/keys/cosmetic_055.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_056.txt
+++ b/lint/keys/cosmetic_056.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_057.txt
+++ b/lint/keys/cosmetic_057.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_058.txt
+++ b/lint/keys/cosmetic_058.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_059.txt
+++ b/lint/keys/cosmetic_059.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_060.txt
+++ b/lint/keys/cosmetic_060.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_061.txt
+++ b/lint/keys/cosmetic_061.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_062.txt
+++ b/lint/keys/cosmetic_062.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_063.txt
+++ b/lint/keys/cosmetic_063.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_064.txt
+++ b/lint/keys/cosmetic_064.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_065.txt
+++ b/lint/keys/cosmetic_065.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_066.txt
+++ b/lint/keys/cosmetic_066.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_067.txt
+++ b/lint/keys/cosmetic_067.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_068.txt
+++ b/lint/keys/cosmetic_068.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_069.txt
+++ b/lint/keys/cosmetic_069.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_070.txt
+++ b/lint/keys/cosmetic_070.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_071.txt
+++ b/lint/keys/cosmetic_071.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_072.txt
+++ b/lint/keys/cosmetic_072.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_073.txt
+++ b/lint/keys/cosmetic_073.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_074.txt
+++ b/lint/keys/cosmetic_074.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_075.txt
+++ b/lint/keys/cosmetic_075.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_076.txt
+++ b/lint/keys/cosmetic_076.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_077.txt
+++ b/lint/keys/cosmetic_077.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_078.txt
+++ b/lint/keys/cosmetic_078.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_079.txt
+++ b/lint/keys/cosmetic_079.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_080.txt
+++ b/lint/keys/cosmetic_080.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_081.txt
+++ b/lint/keys/cosmetic_081.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_082.txt
+++ b/lint/keys/cosmetic_082.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_083.txt
+++ b/lint/keys/cosmetic_083.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_084.txt
+++ b/lint/keys/cosmetic_084.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_085.txt
+++ b/lint/keys/cosmetic_085.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_086.txt
+++ b/lint/keys/cosmetic_086.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_087.txt
+++ b/lint/keys/cosmetic_087.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_088.txt
+++ b/lint/keys/cosmetic_088.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_089.txt
+++ b/lint/keys/cosmetic_089.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_090.txt
+++ b/lint/keys/cosmetic_090.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_091.txt
+++ b/lint/keys/cosmetic_091.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_092.txt
+++ b/lint/keys/cosmetic_092.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_093.txt
+++ b/lint/keys/cosmetic_093.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_094.txt
+++ b/lint/keys/cosmetic_094.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_095.txt
+++ b/lint/keys/cosmetic_095.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_096.txt
+++ b/lint/keys/cosmetic_096.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_097.txt
+++ b/lint/keys/cosmetic_097.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_098.txt
+++ b/lint/keys/cosmetic_098.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/cosmetic_099.txt
+++ b/lint/keys/cosmetic_099.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 2 / 14 required (14.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/cosmetic_100.txt
+++ b/lint/keys/cosmetic_100.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 2 / 14 required (14.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/cosmetic_101.txt
+++ b/lint/keys/cosmetic_101.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 2 / 14 required (14.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/cosmetic_102.txt
+++ b/lint/keys/cosmetic_102.txt
@@ -1,4 +1,4 @@
-Translation coverage: 7.69%
+Translation coverage: 2 / 14 required (14.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/cosmetic_default.txt
+++ b/lint/keys/cosmetic_default.txt
@@ -1,4 +1,4 @@
-Translation coverage: 30.77%
+Translation coverage: 5 / 14 required (35.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/crocodile.txt
+++ b/lint/keys/crocodile.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/fennec.txt
+++ b/lint/keys/fennec.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/final_boss_1_1.txt
+++ b/lint/keys/final_boss_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_1_2.txt
+++ b/lint/keys/final_boss_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_1_3.txt
+++ b/lint/keys/final_boss_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_1_4.txt
+++ b/lint/keys/final_boss_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_1_5.txt
+++ b/lint/keys/final_boss_1_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_1_6.txt
+++ b/lint/keys/final_boss_1_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_1_7.txt
+++ b/lint/keys/final_boss_1_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_2_1.txt
+++ b/lint/keys/final_boss_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_2_2.txt
+++ b/lint/keys/final_boss_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_2_3.txt
+++ b/lint/keys/final_boss_2_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_3_1.txt
+++ b/lint/keys/final_boss_3_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_3_2.txt
+++ b/lint/keys/final_boss_3_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/final_boss_3_3.txt
+++ b/lint/keys/final_boss_3_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/help_birds.txt
+++ b/lint/keys/help_birds.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_fancy_shaders.txt
+++ b/lint/keys/help_fancy_shaders.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_fast_restart.txt
+++ b/lint/keys/help_fast_restart.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el

--- a/lint/keys/help_fish.txt
+++ b/lint/keys/help_fish.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_flowers.txt
+++ b/lint/keys/help_flowers.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_fps_counter.txt
+++ b/lint/keys/help_fps_counter.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/help_gyro_controls.txt
+++ b/lint/keys/help_gyro_controls.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el

--- a/lint/keys/help_hide_inputs.txt
+++ b/lint/keys/help_hide_inputs.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el

--- a/lint/keys/help_invert_camera.txt
+++ b/lint/keys/help_invert_camera.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_key_help.txt
+++ b/lint/keys/help_key_help.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_light_probes.txt
+++ b/lint/keys/help_light_probes.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_lightmaps.txt
+++ b/lint/keys/help_lightmaps.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_shicka_tips.txt
+++ b/lint/keys/help_shicka_tips.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_speedrun_mode.txt
+++ b/lint/keys/help_speedrun_mode.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/help_timer.txt
+++ b/lint/keys/help_timer.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el

--- a/lint/keys/hive_boss_1_1.txt
+++ b/lint/keys/hive_boss_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_2.txt
+++ b/lint/keys/hive_boss_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_3.txt
+++ b/lint/keys/hive_boss_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_4.txt
+++ b/lint/keys/hive_boss_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_5.txt
+++ b/lint/keys/hive_boss_1_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_6.txt
+++ b/lint/keys/hive_boss_1_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_7.txt
+++ b/lint/keys/hive_boss_1_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_1_8.txt
+++ b/lint/keys/hive_boss_1_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_2_1.txt
+++ b/lint/keys/hive_boss_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_2_2.txt
+++ b/lint/keys/hive_boss_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_boss_3_1.txt
+++ b/lint/keys/hive_boss_3_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_ending_1.txt
+++ b/lint/keys/hive_ending_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_ending_2.txt
+++ b/lint/keys/hive_ending_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_ending_3.txt
+++ b/lint/keys/hive_ending_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_ending_4.txt
+++ b/lint/keys/hive_ending_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_maybee.txt
+++ b/lint/keys/hive_maybee.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_shop.txt
+++ b/lint/keys/hive_shop.txt
@@ -1,4 +1,4 @@
-Translation coverage: 30.77%
+Translation coverage: 5 / 14 required (35.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hive_task_boss.txt
+++ b/lint/keys/hive_task_boss.txt
@@ -1,4 +1,4 @@
-Translation coverage: 15.38%
+Translation coverage: 3 / 14 required (21.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/hive_task_gold.txt
+++ b/lint/keys/hive_task_gold.txt
@@ -1,4 +1,4 @@
-Translation coverage: 15.38%
+Translation coverage: 3 / 14 required (21.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/hive_task_level.txt
+++ b/lint/keys/hive_task_level.txt
@@ -1,4 +1,4 @@
-Translation coverage: 15.38%
+Translation coverage: 3 / 14 required (21.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/hub_bear_01.txt
+++ b/lint/keys/hub_bear_01.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_02.txt
+++ b/lint/keys/hub_bear_02.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_03.txt
+++ b/lint/keys/hub_bear_03.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_04.txt
+++ b/lint/keys/hub_bear_04.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_05.txt
+++ b/lint/keys/hub_bear_05.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_06.txt
+++ b/lint/keys/hub_bear_06.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_07.txt
+++ b/lint/keys/hub_bear_07.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_08.txt
+++ b/lint/keys/hub_bear_08.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_09.txt
+++ b/lint/keys/hub_bear_09.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/hub_bear_1.txt
+++ b/lint/keys/hub_bear_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_10.txt
+++ b/lint/keys/hub_bear_10.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_11.txt
+++ b/lint/keys/hub_bear_11.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/hub_bear_12.txt
+++ b/lint/keys/hub_bear_12.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_13.txt
+++ b/lint/keys/hub_bear_13.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_14.txt
+++ b/lint/keys/hub_bear_14.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_15.txt
+++ b/lint/keys/hub_bear_15.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - pt

--- a/lint/keys/hub_bear_16.txt
+++ b/lint/keys/hub_bear_16.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/hub_bear_17.txt
+++ b/lint/keys/hub_bear_17.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_18.txt
+++ b/lint/keys/hub_bear_18.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_19.txt
+++ b/lint/keys/hub_bear_19.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_2.txt
+++ b/lint/keys/hub_bear_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_20.txt
+++ b/lint/keys/hub_bear_20.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_21.txt
+++ b/lint/keys/hub_bear_21.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/hub_bear_22.txt
+++ b/lint/keys/hub_bear_22.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/hub_bear_23.txt
+++ b/lint/keys/hub_bear_23.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_24.txt
+++ b/lint/keys/hub_bear_24.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_bear_25.txt
+++ b/lint/keys/hub_bear_25.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_26.txt
+++ b/lint/keys/hub_bear_26.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_27.txt
+++ b/lint/keys/hub_bear_27.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_28.txt
+++ b/lint/keys/hub_bear_28.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_29.txt
+++ b/lint/keys/hub_bear_29.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_3.txt
+++ b/lint/keys/hub_bear_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_30.txt
+++ b/lint/keys/hub_bear_30.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_31.txt
+++ b/lint/keys/hub_bear_31.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_32.txt
+++ b/lint/keys/hub_bear_32.txt
@@ -1,4 +1,4 @@
-Translation coverage: 61.54%
+Translation coverage: 9 / 14 required (64.29%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/hub_bear_4.txt
+++ b/lint/keys/hub_bear_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_5.txt
+++ b/lint/keys/hub_bear_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_6.txt
+++ b/lint/keys/hub_bear_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_7.txt
+++ b/lint/keys/hub_bear_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_8.txt
+++ b/lint/keys/hub_bear_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_bear_9.txt
+++ b/lint/keys/hub_bear_9.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/hub_capitalos.txt
+++ b/lint/keys/hub_capitalos.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - sv

--- a/lint/keys/hub_capitalus.txt
+++ b/lint/keys/hub_capitalus.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/hub_level4_intro_1.txt
+++ b/lint/keys/hub_level4_intro_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/hub_level4_intro_2.txt
+++ b/lint/keys/hub_level4_intro_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/hub_level4_intro_3.txt
+++ b/lint/keys/hub_level4_intro_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/hub_level4_intro_4.txt
+++ b/lint/keys/hub_level4_intro_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/hub_level4_intro_5.txt
+++ b/lint/keys/hub_level4_intro_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/hub_level4_intro_6.txt
+++ b/lint/keys/hub_level4_intro_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/hub_scientist.txt
+++ b/lint/keys/hub_scientist.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - sv

--- a/lint/keys/hub_sign_1.txt
+++ b/lint/keys/hub_sign_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/hub_tristopio.txt
+++ b/lint/keys/hub_tristopio.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/intro_1.txt
+++ b/lint/keys/intro_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_10.txt
+++ b/lint/keys/intro_10.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_11.txt
+++ b/lint/keys/intro_11.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_12.txt
+++ b/lint/keys/intro_12.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_1_1.txt
+++ b/lint/keys/intro_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_1_2.txt
+++ b/lint/keys/intro_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_1_3.txt
+++ b/lint/keys/intro_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_2.txt
+++ b/lint/keys/intro_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_2_1.txt
+++ b/lint/keys/intro_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_2_2.txt
+++ b/lint/keys/intro_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_2_3.txt
+++ b/lint/keys/intro_2_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_3.txt
+++ b/lint/keys/intro_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_3_1.txt
+++ b/lint/keys/intro_3_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_3_2.txt
+++ b/lint/keys/intro_3_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_4.txt
+++ b/lint/keys/intro_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_4_1.txt
+++ b/lint/keys/intro_4_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_4_2.txt
+++ b/lint/keys/intro_4_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_4_3.txt
+++ b/lint/keys/intro_4_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/intro_5.txt
+++ b/lint/keys/intro_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_6.txt
+++ b/lint/keys/intro_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_7.txt
+++ b/lint/keys/intro_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_8.txt
+++ b/lint/keys/intro_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/intro_9.txt
+++ b/lint/keys/intro_9.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/level1_boss_1.txt
+++ b/lint/keys/level1_boss_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level1_boss_1_1.txt
+++ b/lint/keys/level1_boss_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_1_2.txt
+++ b/lint/keys/level1_boss_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_1_3.txt
+++ b/lint/keys/level1_boss_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_1_4.txt
+++ b/lint/keys/level1_boss_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_2.txt
+++ b/lint/keys/level1_boss_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level1_boss_2_1.txt
+++ b/lint/keys/level1_boss_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_2_2.txt
+++ b/lint/keys/level1_boss_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_2_3.txt
+++ b/lint/keys/level1_boss_2_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_boss_3.txt
+++ b/lint/keys/level1_boss_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level1_boss_4.txt
+++ b/lint/keys/level1_boss_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level1_boss_5.txt
+++ b/lint/keys/level1_boss_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level1_boss__1.txt
+++ b/lint/keys/level1_boss__1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - tr

--- a/lint/keys/level1_boss__2.txt
+++ b/lint/keys/level1_boss__2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - tr

--- a/lint/keys/level1_boss__3.txt
+++ b/lint/keys/level1_boss__3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - tr

--- a/lint/keys/level1_boss__4.txt
+++ b/lint/keys/level1_boss__4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - tr

--- a/lint/keys/level1_boss__5.txt
+++ b/lint/keys/level1_boss__5.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - tr

--- a/lint/keys/level1_intro_1.txt
+++ b/lint/keys/level1_intro_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_intro_2.txt
+++ b/lint/keys/level1_intro_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_intro_3.txt
+++ b/lint/keys/level1_intro_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_intro_4.txt
+++ b/lint/keys/level1_intro_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level1_sign_1.txt
+++ b/lint/keys/level1_sign_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/level1_sign_2.txt
+++ b/lint/keys/level1_sign_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_sign_3.txt
+++ b/lint/keys/level1_sign_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_sign_4.txt
+++ b/lint/keys/level1_sign_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_sign_5.txt
+++ b/lint/keys/level1_sign_5.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_sign_6.txt
+++ b/lint/keys/level1_sign_6.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_stair_cutscene_1.txt
+++ b/lint/keys/level1_stair_cutscene_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/level1_stair_cutscene_2.txt
+++ b/lint/keys/level1_stair_cutscene_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/level1_start_cutscene_1.txt
+++ b/lint/keys/level1_start_cutscene_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/level1_start_cutscene_2.txt
+++ b/lint/keys/level1_start_cutscene_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/level1_start_cutscene_3.txt
+++ b/lint/keys/level1_start_cutscene_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/level1_start_cutscene_4.txt
+++ b/lint/keys/level1_start_cutscene_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/level1_turtle_1.txt
+++ b/lint/keys/level1_turtle_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_turtle_2.txt
+++ b/lint/keys/level1_turtle_2.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/level1_turtle_3.txt
+++ b/lint/keys/level1_turtle_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_turtle_4.txt
+++ b/lint/keys/level1_turtle_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_turtle_5.txt
+++ b/lint/keys/level1_turtle_5.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/level1_turtle_6.txt
+++ b/lint/keys/level1_turtle_6.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_turtle_7.txt
+++ b/lint/keys/level1_turtle_7.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - sv

--- a/lint/keys/level1_tutorial_0.txt
+++ b/lint/keys/level1_tutorial_0.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level1_tutorial_1.txt
+++ b/lint/keys/level1_tutorial_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - es
 - sv

--- a/lint/keys/level1_tutorial_2.txt
+++ b/lint/keys/level1_tutorial_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have multiple translations:

--- a/lint/keys/level1_tutorial_3.txt
+++ b/lint/keys/level1_tutorial_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have multiple translations:

--- a/lint/keys/level2_boss_1.txt
+++ b/lint/keys/level2_boss_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - tr
 The following locales have transparent translations:

--- a/lint/keys/level2_boss_2.txt
+++ b/lint/keys/level2_boss_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level2_boss_3.txt
+++ b/lint/keys/level2_boss_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level2_boss_4.txt
+++ b/lint/keys/level2_boss_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level2_boss_5.txt
+++ b/lint/keys/level2_boss_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level2_penguin_1.txt
+++ b/lint/keys/level2_penguin_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_penguin_2.txt
+++ b/lint/keys/level2_penguin_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_penguin_3.txt
+++ b/lint/keys/level2_penguin_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_penguin_4.txt
+++ b/lint/keys/level2_penguin_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_penguin_5.txt
+++ b/lint/keys/level2_penguin_5.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_penguin_6.txt
+++ b/lint/keys/level2_penguin_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_reindeer_1.txt
+++ b/lint/keys/level2_reindeer_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_reindeer_2.txt
+++ b/lint/keys/level2_reindeer_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_reindeer_3.txt
+++ b/lint/keys/level2_reindeer_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_sign_1.txt
+++ b/lint/keys/level2_sign_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_sign_2.txt
+++ b/lint/keys/level2_sign_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_sign_3.txt
+++ b/lint/keys/level2_sign_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_sign_4.txt
+++ b/lint/keys/level2_sign_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_sign_5.txt
+++ b/lint/keys/level2_sign_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_start_cutscene_1.txt
+++ b/lint/keys/level2_start_cutscene_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_start_cutscene_2.txt
+++ b/lint/keys/level2_start_cutscene_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level2_start_cutscene_3.txt
+++ b/lint/keys/level2_start_cutscene_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level2_start_cutscene_4.txt
+++ b/lint/keys/level2_start_cutscene_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_boss_1.txt
+++ b/lint/keys/level3_boss_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level3_boss_1_1.txt
+++ b/lint/keys/level3_boss_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level3_boss_1_2.txt
+++ b/lint/keys/level3_boss_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level3_boss_1_3.txt
+++ b/lint/keys/level3_boss_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level3_boss_1_4.txt
+++ b/lint/keys/level3_boss_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level3_boss_2.txt
+++ b/lint/keys/level3_boss_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level3_boss_2_1.txt
+++ b/lint/keys/level3_boss_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level3_boss_2_2.txt
+++ b/lint/keys/level3_boss_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level3_boss_3.txt
+++ b/lint/keys/level3_boss_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level3_crocodile_1.txt
+++ b/lint/keys/level3_crocodile_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_crocodile_2.txt
+++ b/lint/keys/level3_crocodile_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_crocodile_3.txt
+++ b/lint/keys/level3_crocodile_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_crocodile_4.txt
+++ b/lint/keys/level3_crocodile_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_1.txt
+++ b/lint/keys/level3_fennec_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_2.txt
+++ b/lint/keys/level3_fennec_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_3.txt
+++ b/lint/keys/level3_fennec_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_4.txt
+++ b/lint/keys/level3_fennec_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_5.txt
+++ b/lint/keys/level3_fennec_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_6.txt
+++ b/lint/keys/level3_fennec_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_fennec_7.txt
+++ b/lint/keys/level3_fennec_7.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_fennec_8.txt
+++ b/lint/keys/level3_fennec_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_intro_1.txt
+++ b/lint/keys/level3_intro_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_intro_2.txt
+++ b/lint/keys/level3_intro_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_intro_3.txt
+++ b/lint/keys/level3_intro_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_intro_4.txt
+++ b/lint/keys/level3_intro_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_sign_1.txt
+++ b/lint/keys/level3_sign_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level3_sign_2.txt
+++ b/lint/keys/level3_sign_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level3_sign_3.txt
+++ b/lint/keys/level3_sign_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/level4_boss_1.txt
+++ b/lint/keys/level4_boss_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level4_boss_1_1.txt
+++ b/lint/keys/level4_boss_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_1_2.txt
+++ b/lint/keys/level4_boss_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_1_3.txt
+++ b/lint/keys/level4_boss_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_1_4.txt
+++ b/lint/keys/level4_boss_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_1_5.txt
+++ b/lint/keys/level4_boss_1_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_2.txt
+++ b/lint/keys/level4_boss_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level4_boss_2_1.txt
+++ b/lint/keys/level4_boss_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_2_2.txt
+++ b/lint/keys/level4_boss_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_2_3.txt
+++ b/lint/keys/level4_boss_2_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_2_4.txt
+++ b/lint/keys/level4_boss_2_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_boss_3.txt
+++ b/lint/keys/level4_boss_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level4_boss_4.txt
+++ b/lint/keys/level4_boss_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level4_boss_5.txt
+++ b/lint/keys/level4_boss_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level4_boss_6.txt
+++ b/lint/keys/level4_boss_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/level4_crogo_1.txt
+++ b/lint/keys/level4_crogo_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_crogo_2.txt
+++ b/lint/keys/level4_crogo_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_crogo_3.txt
+++ b/lint/keys/level4_crogo_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level4_crogo_4.txt
+++ b/lint/keys/level4_crogo_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_hairless_rat.txt
+++ b/lint/keys/level4_hairless_rat.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/level4_intro_1.txt
+++ b/lint/keys/level4_intro_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level4_intro_2.txt
+++ b/lint/keys/level4_intro_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_intro_3.txt
+++ b/lint/keys/level4_intro_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level4_intro_4.txt
+++ b/lint/keys/level4_intro_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_mouse_1.txt
+++ b/lint/keys/level4_mouse_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level4_mouse_2.txt
+++ b/lint/keys/level4_mouse_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_mouse_3.txt
+++ b/lint/keys/level4_mouse_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level4_mouse_4.txt
+++ b/lint/keys/level4_mouse_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_mouse_5.txt
+++ b/lint/keys/level4_mouse_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_mouse_6.txt
+++ b/lint/keys/level4_mouse_6.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/level4_mouse_7.txt
+++ b/lint/keys/level4_mouse_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_mouse_8.txt
+++ b/lint/keys/level4_mouse_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/level4_sign_1.txt
+++ b/lint/keys/level4_sign_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/loading_1.txt
+++ b/lint/keys/loading_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/loading_10.txt
+++ b/lint/keys/loading_10.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_11.txt
+++ b/lint/keys/loading_11.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_12.txt
+++ b/lint/keys/loading_12.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_13.txt
+++ b/lint/keys/loading_13.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/loading_2.txt
+++ b/lint/keys/loading_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_3.txt
+++ b/lint/keys/loading_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/loading_4.txt
+++ b/lint/keys/loading_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_5.txt
+++ b/lint/keys/loading_5.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_6.txt
+++ b/lint/keys/loading_6.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_7.txt
+++ b/lint/keys/loading_7.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/loading_8.txt
+++ b/lint/keys/loading_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/loading_9.txt
+++ b/lint/keys/loading_9.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/merch_ad.txt
+++ b/lint/keys/merch_ad.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/mission_0_1.txt
+++ b/lint/keys/mission_0_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_0_2.txt
+++ b/lint/keys/mission_0_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_0_3.txt
+++ b/lint/keys/mission_0_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_1_1.txt
+++ b/lint/keys/mission_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_2_1.txt
+++ b/lint/keys/mission_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_3_1.txt
+++ b/lint/keys/mission_3_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_4_1.txt
+++ b/lint/keys/mission_4_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_4_2.txt
+++ b/lint/keys/mission_4_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_5_1.txt
+++ b/lint/keys/mission_5_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_6_1.txt
+++ b/lint/keys/mission_6_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_6_2.txt
+++ b/lint/keys/mission_6_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_airplane.txt
+++ b/lint/keys/mission_airplane.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_egg.txt
+++ b/lint/keys/mission_egg.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_electricity.txt
+++ b/lint/keys/mission_electricity.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_flooding.txt
+++ b/lint/keys/mission_flooding.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_lava.txt
+++ b/lint/keys/mission_lava.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_parkour.txt
+++ b/lint/keys/mission_parkour.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mission_race.txt
+++ b/lint/keys/mission_race.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/mouse.txt
+++ b/lint/keys/mouse.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/party_bee_1.txt
+++ b/lint/keys/party_bee_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_bee_2.txt
+++ b/lint/keys/party_bee_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_bee_3.txt
+++ b/lint/keys/party_bee_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_capitalos.txt
+++ b/lint/keys/party_capitalos.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_capitalus.txt
+++ b/lint/keys/party_capitalus.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_crocodile_1.txt
+++ b/lint/keys/party_crocodile_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_crocodile_2.txt
+++ b/lint/keys/party_crocodile_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_crocodile_3.txt
+++ b/lint/keys/party_crocodile_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_crocodile_4.txt
+++ b/lint/keys/party_crocodile_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_fennec_1.txt
+++ b/lint/keys/party_fennec_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_fennec_2.txt
+++ b/lint/keys/party_fennec_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_fennec_3.txt
+++ b/lint/keys/party_fennec_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_fennec_4.txt
+++ b/lint/keys/party_fennec_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_fennec_5.txt
+++ b/lint/keys/party_fennec_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_penguin_1.txt
+++ b/lint/keys/party_penguin_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_penguin_2.txt
+++ b/lint/keys/party_penguin_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_queen.txt
+++ b/lint/keys/party_queen.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_reindeer_1.txt
+++ b/lint/keys/party_reindeer_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_reindeer_2.txt
+++ b/lint/keys/party_reindeer_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_reindeer_3.txt
+++ b/lint/keys/party_reindeer_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_tristopio.txt
+++ b/lint/keys/party_tristopio.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_turtle_1.txt
+++ b/lint/keys/party_turtle_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_turtle_2.txt
+++ b/lint/keys/party_turtle_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_turtle_3.txt
+++ b/lint/keys/party_turtle_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_turtle_4.txt
+++ b/lint/keys/party_turtle_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_turtle_5.txt
+++ b/lint/keys/party_turtle_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/party_turtle_6.txt
+++ b/lint/keys/party_turtle_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/penguin.txt
+++ b/lint/keys/penguin.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/queen.txt
+++ b/lint/keys/queen.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/rat_boss.txt
+++ b/lint/keys/rat_boss.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/reindeer.txt
+++ b/lint/keys/reindeer.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/save_bear_tip_1.txt
+++ b/lint/keys/save_bear_tip_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/save_bear_tip_2.txt
+++ b/lint/keys/save_bear_tip_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/scientist.txt
+++ b/lint/keys/scientist.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/scientist_cutscene_1_1.txt
+++ b/lint/keys/scientist_cutscene_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_1_2.txt
+++ b/lint/keys/scientist_cutscene_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_1_3.txt
+++ b/lint/keys/scientist_cutscene_1_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_1_4.txt
+++ b/lint/keys/scientist_cutscene_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_1_5.txt
+++ b/lint/keys/scientist_cutscene_1_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_1_6.txt
+++ b/lint/keys/scientist_cutscene_1_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_1_7.txt
+++ b/lint/keys/scientist_cutscene_1_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_2_1.txt
+++ b/lint/keys/scientist_cutscene_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_2_2.txt
+++ b/lint/keys/scientist_cutscene_2_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_3_1.txt
+++ b/lint/keys/scientist_cutscene_3_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/scientist_cutscene_3_2.txt
+++ b/lint/keys/scientist_cutscene_3_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/shicka_0_1.txt
+++ b/lint/keys/shicka_0_1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/shicka_0_2.txt
+++ b/lint/keys/shicka_0_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/shicka_0_3.txt
+++ b/lint/keys/shicka_0_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/shicka_0_4.txt
+++ b/lint/keys/shicka_0_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have transparent translations:

--- a/lint/keys/shicka_1_1.txt
+++ b/lint/keys/shicka_1_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_1_2.txt
+++ b/lint/keys/shicka_1_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_1_3.txt
+++ b/lint/keys/shicka_1_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_1_4.txt
+++ b/lint/keys/shicka_1_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_1_5.txt
+++ b/lint/keys/shicka_1_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_1_6.txt
+++ b/lint/keys/shicka_1_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_2_1.txt
+++ b/lint/keys/shicka_2_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_2_2.txt
+++ b/lint/keys/shicka_2_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_2_3.txt
+++ b/lint/keys/shicka_2_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_2_4.txt
+++ b/lint/keys/shicka_2_4.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_2_5.txt
+++ b/lint/keys/shicka_2_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_3_1.txt
+++ b/lint/keys/shicka_3_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_3_2.txt
+++ b/lint/keys/shicka_3_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_3_3.txt
+++ b/lint/keys/shicka_3_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_3_4.txt
+++ b/lint/keys/shicka_3_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_3_5.txt
+++ b/lint/keys/shicka_3_5.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_3_6.txt
+++ b/lint/keys/shicka_3_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_3_7.txt
+++ b/lint/keys/shicka_3_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/shicka_4_1.txt
+++ b/lint/keys/shicka_4_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_4_2.txt
+++ b/lint/keys/shicka_4_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/shicka_4_3.txt
+++ b/lint/keys/shicka_4_3.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_4_4.txt
+++ b/lint/keys/shicka_4_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/shicka_4_5.txt
+++ b/lint/keys/shicka_4_5.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/shicka_hive_1.txt
+++ b/lint/keys/shicka_hive_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/shicka_hive_2.txt
+++ b/lint/keys/shicka_hive_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/shicka_hive_3.txt
+++ b/lint/keys/shicka_hive_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 38.46%
+Translation coverage: 6 / 14 required (42.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/sign.txt
+++ b/lint/keys/sign.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/sign_help.txt
+++ b/lint/keys/sign_help.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - de
 - el

--- a/lint/keys/sticker_found.txt
+++ b/lint/keys/sticker_found.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/studio_help_1.txt
+++ b/lint/keys/studio_help_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/studio_help_2.txt
+++ b/lint/keys/studio_help_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/studio_help_3.txt
+++ b/lint/keys/studio_help_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/studio_help_4.txt
+++ b/lint/keys/studio_help_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/studio_help_5.txt
+++ b/lint/keys/studio_help_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/time_format.txt
+++ b/lint/keys/time_format.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/title_gameplay.txt
+++ b/lint/keys/title_gameplay.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/title_graphics1.txt
+++ b/lint/keys/title_graphics1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/title_graphics2.txt
+++ b/lint/keys/title_graphics2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/title_sound.txt
+++ b/lint/keys/title_sound.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/tristopio_ad.txt
+++ b/lint/keys/tristopio_ad.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/tristopio_no_life.txt
+++ b/lint/keys/tristopio_no_life.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/tristopio_practice.txt
+++ b/lint/keys/tristopio_practice.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/tristopio_practice_info.txt
+++ b/lint/keys/tristopio_practice_info.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/tristopio_start.txt
+++ b/lint/keys/tristopio_start.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/turtle.txt
+++ b/lint/keys/turtle.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/tutorial_shicka_1.txt
+++ b/lint/keys/tutorial_shicka_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have multiple translations:
 - pl (2)
 - ru (2)

--- a/lint/keys/tutorial_shicka_2.txt
+++ b/lint/keys/tutorial_shicka_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have multiple translations:
 - pl (2)
 - ru (2)

--- a/lint/keys/tutorial_shicka_3.txt
+++ b/lint/keys/tutorial_shicka_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have multiple translations:
 - pl (2)
 - ru (2)

--- a/lint/keys/tutorial_shicka_4.txt
+++ b/lint/keys/tutorial_shicka_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have multiple translations:
 - pl (2)
 - ru (2)

--- a/lint/keys/tutorial_shicka_5.txt
+++ b/lint/keys/tutorial_shicka_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have multiple translations:
 - pl (2)
 - ru (2)

--- a/lint/keys/tutorial_shicka_6.txt
+++ b/lint/keys/tutorial_shicka_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have multiple translations:
 - pl (2)
 - ru (2)

--- a/lint/keys/tutorial_sign_01.txt
+++ b/lint/keys/tutorial_sign_01.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_02.txt
+++ b/lint/keys/tutorial_sign_02.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_03.txt
+++ b/lint/keys/tutorial_sign_03.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_04.txt
+++ b/lint/keys/tutorial_sign_04.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_05.txt
+++ b/lint/keys/tutorial_sign_05.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_06.txt
+++ b/lint/keys/tutorial_sign_06.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_07.txt
+++ b/lint/keys/tutorial_sign_07.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_08.txt
+++ b/lint/keys/tutorial_sign_08.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_09.txt
+++ b/lint/keys/tutorial_sign_09.txt
@@ -1,4 +1,4 @@
-Translation coverage: 23.08%
+Translation coverage: 4 / 14 required (28.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_1.txt
+++ b/lint/keys/tutorial_sign_1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_10.txt
+++ b/lint/keys/tutorial_sign_10.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/tutorial_sign_11.txt
+++ b/lint/keys/tutorial_sign_11.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/tutorial_sign_12.txt
+++ b/lint/keys/tutorial_sign_12.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/tutorial_sign_2.txt
+++ b/lint/keys/tutorial_sign_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_3.txt
+++ b/lint/keys/tutorial_sign_3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_4.txt
+++ b/lint/keys/tutorial_sign_4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_5.txt
+++ b/lint/keys/tutorial_sign_5.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_6.txt
+++ b/lint/keys/tutorial_sign_6.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_7.txt
+++ b/lint/keys/tutorial_sign_7.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_8.txt
+++ b/lint/keys/tutorial_sign_8.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/tutorial_sign_9.txt
+++ b/lint/keys/tutorial_sign_9.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el
 - es

--- a/lint/keys/ui_100coins.txt
+++ b/lint/keys/ui_100coins.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_100coins_desc.txt
+++ b/lint/keys/ui_100coins_desc.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_2x_coins.txt
+++ b/lint/keys/ui_2x_coins.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_6hp.txt
+++ b/lint/keys/ui_6hp.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_6hp_desc.txt
+++ b/lint/keys/ui_6hp_desc.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_aboutbutton.txt
+++ b/lint/keys/ui_aboutbutton.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_achievements.txt
+++ b/lint/keys/ui_achievements.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_ad_text.txt
+++ b/lint/keys/ui_ad_text.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_arcade_enter.txt
+++ b/lint/keys/ui_arcade_enter.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_arcade_exit.txt
+++ b/lint/keys/ui_arcade_exit.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_arcade_stay.txt
+++ b/lint/keys/ui_arcade_stay.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_arcade_world.txt
+++ b/lint/keys/ui_arcade_world.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_bear_name.txt
+++ b/lint/keys/ui_bear_name.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_bears_saved.txt
+++ b/lint/keys/ui_bears_saved.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_best_time.txt
+++ b/lint/keys/ui_best_time.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_bestcoins.txt
+++ b/lint/keys/ui_bestcoins.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_binding.txt
+++ b/lint/keys/ui_binding.txt
@@ -1,4 +1,4 @@
-Translation coverage: 69.23%
+Translation coverage: 10 / 14 required (71.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/ui_birds.txt
+++ b/lint/keys/ui_birds.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_buy.txt
+++ b/lint/keys/ui_buy.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_camera_sensitivity.txt
+++ b/lint/keys/ui_camera_sensitivity.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_cancel.txt
+++ b/lint/keys/ui_cancel.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_capitalus_hint.txt
+++ b/lint/keys/ui_capitalus_hint.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_cloud.txt
+++ b/lint/keys/ui_cloud.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_cloud_load.txt
+++ b/lint/keys/ui_cloud_load.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_cloud_save.txt
+++ b/lint/keys/ui_cloud_save.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_coin_count.txt
+++ b/lint/keys/ui_coin_count.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_coin_detector.txt
+++ b/lint/keys/ui_coin_detector.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_coin_detector_confirm.txt
+++ b/lint/keys/ui_coin_detector_confirm.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_coin_detector_desc.txt
+++ b/lint/keys/ui_coin_detector_desc.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_coins.txt
+++ b/lint/keys/ui_coins.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_coins_found.txt
+++ b/lint/keys/ui_coins_found.txt
@@ -1,4 +1,4 @@
-Translation coverage: 15.38%
+Translation coverage: 3 / 14 required (21.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/ui_connected.txt
+++ b/lint/keys/ui_connected.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_cosm_already_own.txt
+++ b/lint/keys/ui_cosm_already_own.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/ui_cosm_buy.txt
+++ b/lint/keys/ui_cosm_buy.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_cosm_instead.txt
+++ b/lint/keys/ui_cosm_instead.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/ui_cosm_new.txt
+++ b/lint/keys/ui_cosm_new.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_cosm_owned.txt
+++ b/lint/keys/ui_cosm_owned.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_cosm_shop.txt
+++ b/lint/keys/ui_cosm_shop.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_cosm_won.txt
+++ b/lint/keys/ui_cosm_won.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pl
 - sv

--- a/lint/keys/ui_credits.txt
+++ b/lint/keys/ui_credits.txt
@@ -1,4 +1,4 @@
-Translation coverage: 30.77%
+Translation coverage: 5 / 14 required (35.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/ui_delete.txt
+++ b/lint/keys/ui_delete.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_deleteconfirm.txt
+++ b/lint/keys/ui_deleteconfirm.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_disconnected.txt
+++ b/lint/keys/ui_disconnected.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_discord.txt
+++ b/lint/keys/ui_discord.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_donator_1.txt
+++ b/lint/keys/ui_donator_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_donator_2.txt
+++ b/lint/keys/ui_donator_2.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_donator_info.txt
+++ b/lint/keys/ui_donator_info.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_donator_title.txt
+++ b/lint/keys/ui_donator_title.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_empty.txt
+++ b/lint/keys/ui_empty.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_exit.txt
+++ b/lint/keys/ui_exit.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_exitgame.txt
+++ b/lint/keys/ui_exitgame.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_fancy_shaders.txt
+++ b/lint/keys/ui_fancy_shaders.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/ui_fast_restart.txt
+++ b/lint/keys/ui_fast_restart.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_fish.txt
+++ b/lint/keys/ui_fish.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/ui_flowers.txt
+++ b/lint/keys/ui_flowers.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_fps_counter.txt
+++ b/lint/keys/ui_fps_counter.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_framerate.txt
+++ b/lint/keys/ui_framerate.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - es

--- a/lint/keys/ui_freed.txt
+++ b/lint/keys/ui_freed.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_game_creator.txt
+++ b/lint/keys/ui_game_creator.txt
@@ -1,4 +1,4 @@
-Translation coverage: 30.77%
+Translation coverage: 5 / 14 required (35.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/ui_game_over.txt
+++ b/lint/keys/ui_game_over.txt
@@ -1,4 +1,4 @@
-Translation coverage: 30.77%
+Translation coverage: 5 / 14 required (35.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/ui_go.txt
+++ b/lint/keys/ui_go.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_gold_time.txt
+++ b/lint/keys/ui_gold_time.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_gyro_controls.txt
+++ b/lint/keys/ui_gyro_controls.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - el

--- a/lint/keys/ui_gyroscope.txt
+++ b/lint/keys/ui_gyroscope.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/ui_hide_inputs.txt
+++ b/lint/keys/ui_hide_inputs.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_hive.txt
+++ b/lint/keys/ui_hive.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_hubconfirm.txt
+++ b/lint/keys/ui_hubconfirm.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_in.txt
+++ b/lint/keys/ui_in.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_introconfirm.txt
+++ b/lint/keys/ui_introconfirm.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_invert_camera.txt
+++ b/lint/keys/ui_invert_camera.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_item_time.txt
+++ b/lint/keys/ui_item_time.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_key_help.txt
+++ b/lint/keys/ui_key_help.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_language.txt
+++ b/lint/keys/ui_language.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_leaderboard_help.txt
+++ b/lint/keys/ui_leaderboard_help.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_level1.txt
+++ b/lint/keys/ui_level1.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/keys/ui_level2.txt
+++ b/lint/keys/ui_level2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_level3.txt
+++ b/lint/keys/ui_level3.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_level4.txt
+++ b/lint/keys/ui_level4.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/ui_life.txt
+++ b/lint/keys/ui_life.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_light_probes.txt
+++ b/lint/keys/ui_light_probes.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 2 / 2 required (100.00%), 12 / 12 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/ui_lightmaps.txt
+++ b/lint/keys/ui_lightmaps.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 2 / 2 required (100.00%), 12 / 12 optional (100.00%)
 The following locales have transparent translations:
 - de
 - el

--- a/lint/keys/ui_load.txt
+++ b/lint/keys/ui_load.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_load_ad.txt
+++ b/lint/keys/ui_load_ad.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have transparent translations:

--- a/lint/keys/ui_loading.txt
+++ b/lint/keys/ui_loading.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_loading_google.txt
+++ b/lint/keys/ui_loading_google.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_lootbox.txt
+++ b/lint/keys/ui_lootbox.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_main_menu_1.txt
+++ b/lint/keys/ui_main_menu_1.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_main_menu_2.txt
+++ b/lint/keys/ui_main_menu_2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_mission_fail.txt
+++ b/lint/keys/ui_mission_fail.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_mission_win.txt
+++ b/lint/keys/ui_mission_win.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_music.txt
+++ b/lint/keys/ui_music.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_new_best.txt
+++ b/lint/keys/ui_new_best.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_next_mission.txt
+++ b/lint/keys/ui_next_mission.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_no_boost.txt
+++ b/lint/keys/ui_no_boost.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_open_shop.txt
+++ b/lint/keys/ui_open_shop.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_options.txt
+++ b/lint/keys/ui_options.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_oxygen.txt
+++ b/lint/keys/ui_oxygen.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_performance.txt
+++ b/lint/keys/ui_performance.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - es

--- a/lint/keys/ui_progression.txt
+++ b/lint/keys/ui_progression.txt
@@ -1,4 +1,4 @@
-Translation coverage: 15.38%
+Translation coverage: 3 / 14 required (21.43%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - de
 - el

--- a/lint/keys/ui_quality.txt
+++ b/lint/keys/ui_quality.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_quality0.txt
+++ b/lint/keys/ui_quality0.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_quality1.txt
+++ b/lint/keys/ui_quality1.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - es

--- a/lint/keys/ui_quality2.txt
+++ b/lint/keys/ui_quality2.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_quitconfirm.txt
+++ b/lint/keys/ui_quitconfirm.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_rate_game.txt
+++ b/lint/keys/ui_rate_game.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_restart.txt
+++ b/lint/keys/ui_restart.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_restartconfirm.txt
+++ b/lint/keys/ui_restartconfirm.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_resume.txt
+++ b/lint/keys/ui_resume.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_returntohub.txt
+++ b/lint/keys/ui_returntohub.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_returntotitle.txt
+++ b/lint/keys/ui_returntotitle.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_reversed.txt
+++ b/lint/keys/ui_reversed.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_revive.txt
+++ b/lint/keys/ui_revive.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_save.txt
+++ b/lint/keys/ui_save.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_save_cloud.txt
+++ b/lint/keys/ui_save_cloud.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pt
 - ru

--- a/lint/keys/ui_select_quality.txt
+++ b/lint/keys/ui_select_quality.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_sfx_volume.txt
+++ b/lint/keys/ui_sfx_volume.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_shadows.txt
+++ b/lint/keys/ui_shadows.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_shicka_tips.txt
+++ b/lint/keys/ui_shicka_tips.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_shop.txt
+++ b/lint/keys/ui_shop.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_shop_future.txt
+++ b/lint/keys/ui_shop_future.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_shopinfo.txt
+++ b/lint/keys/ui_shopinfo.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_show_cloud.txt
+++ b/lint/keys/ui_show_cloud.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - pt

--- a/lint/keys/ui_snow_cloud.txt
+++ b/lint/keys/ui_snow_cloud.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 0 / 0 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have extra translations:
 - ru

--- a/lint/keys/ui_speedrun_mode.txt
+++ b/lint/keys/ui_speedrun_mode.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_start.txt
+++ b/lint/keys/ui_start.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - es

--- a/lint/keys/ui_stickers_found.txt
+++ b/lint/keys/ui_stickers_found.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_time.txt
+++ b/lint/keys/ui_time.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es
 - sv

--- a/lint/keys/ui_timer.txt
+++ b/lint/keys/ui_timer.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - de
 - es

--- a/lint/keys/ui_titleconfirm.txt
+++ b/lint/keys/ui_titleconfirm.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/keys/ui_tokens.txt
+++ b/lint/keys/ui_tokens.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_tristopio_info.txt
+++ b/lint/keys/ui_tristopio_info.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_tristopio_title.txt
+++ b/lint/keys/ui_tristopio_title.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_unlock.txt
+++ b/lint/keys/ui_unlock.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have transparent translations:

--- a/lint/keys/ui_vehicle_controls.txt
+++ b/lint/keys/ui_vehicle_controls.txt
@@ -1,4 +1,4 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - el
 - es

--- a/lint/keys/ui_version.txt
+++ b/lint/keys/ui_version.txt
@@ -1,4 +1,4 @@
-Translation coverage: 30.77%
+Translation coverage: 5 / 14 required (35.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - es

--- a/lint/keys/ui_watch.txt
+++ b/lint/keys/ui_watch.txt
@@ -1,4 +1,4 @@
-Translation coverage: 84.62%
+Translation coverage: 12 / 14 required (85.71%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - sv

--- a/lint/keys/ui_watch_trailer.txt
+++ b/lint/keys/ui_watch_trailer.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.31%
+Translation coverage: 13 / 14 required (92.86%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - sv
 The following locales have transparent translations:

--- a/lint/keys/ui_website.txt
+++ b/lint/keys/ui_website.txt
@@ -1,4 +1,4 @@
-Translation coverage: 76.92%
+Translation coverage: 11 / 14 required (78.57%), 0 / 0 optional (100.00%)
 The following locales have missing translations:
 - el
 - it

--- a/lint/keys/ui_yes.txt
+++ b/lint/keys/ui_yes.txt
@@ -1,3 +1,3 @@
-Translation coverage: 100.00%
+Translation coverage: 14 / 14 required (100.00%), 0 / 0 optional (100.00%)
 The following locales have transparent translations:
 - es

--- a/lint/locales/de.txt
+++ b/lint/locales/de.txt
@@ -1,4 +1,4 @@
-Translation coverage: 92.43%
+Translation coverage: 584 / 593 required (98.48%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - arcade_1_3
 - arcade_intro_2

--- a/lint/locales/el.txt
+++ b/lint/locales/el.txt
@@ -1,4 +1,4 @@
-Translation coverage: 45.11%
+Translation coverage: 284 / 593 required (47.89%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - arcade_1_3
 - arcade_intro_2

--- a/lint/locales/en.txt
+++ b/lint/locales/en.txt
@@ -1,1 +1,1 @@
-Translation coverage: 100.00%
+Translation coverage: 634 / 634 required (100.00%), 0 / 0 optional (100.00%)

--- a/lint/locales/es.txt
+++ b/lint/locales/es.txt
@@ -1,4 +1,4 @@
-Translation coverage: 57.10%
+Translation coverage: 360 / 593 required (60.71%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - final_boss_1_1
 - final_boss_1_2

--- a/lint/locales/fr.txt
+++ b/lint/locales/fr.txt
@@ -1,4 +1,4 @@
-Translation coverage: 94.01%
+Translation coverage: 593 / 593 required (100.00%), 3 / 41 optional (7.32%)
 The following keys have extra translations:
 - hub_level4_intro_1
 - hub_level4_intro_2

--- a/lint/locales/id.txt
+++ b/lint/locales/id.txt
@@ -1,4 +1,4 @@
-Translation coverage: 57.26%
+Translation coverage: 361 / 593 required (60.88%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - arcade_intro_2
 - final_boss_1_1

--- a/lint/locales/it.txt
+++ b/lint/locales/it.txt
@@ -1,4 +1,4 @@
-Translation coverage: 53.47%
+Translation coverage: 337 / 593 required (56.83%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - arcade_1_3
 - arcade_intro_2

--- a/lint/locales/ja.txt
+++ b/lint/locales/ja.txt
@@ -1,4 +1,4 @@
-Translation coverage: 53.63%
+Translation coverage: 340 / 634 required (53.63%), 0 / 0 optional (100.00%)
 The following keys have extra translations:
 - arcade_intro_2
 - final_boss_1_1

--- a/lint/locales/nl.txt
+++ b/lint/locales/nl.txt
@@ -1,4 +1,4 @@
-Translation coverage: 57.26%
+Translation coverage: 361 / 593 required (60.88%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - final_boss_1_1
 - final_boss_1_2

--- a/lint/locales/pl.txt
+++ b/lint/locales/pl.txt
@@ -1,4 +1,4 @@
-Translation coverage: 93.53%
+Translation coverage: 552 / 593 required (93.09%), 41 / 41 optional (100.00%)
 The following keys have extra translations:
 - action_break
 - brother

--- a/lint/locales/pt.txt
+++ b/lint/locales/pt.txt
@@ -1,4 +1,4 @@
-Translation coverage: 93.22%
+Translation coverage: 589 / 593 required (99.33%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - hub_level4_intro_1
 - hub_level4_intro_2

--- a/lint/locales/ru.txt
+++ b/lint/locales/ru.txt
@@ -1,4 +1,4 @@
-Translation coverage: 88.17%
+Translation coverage: 557 / 593 required (93.93%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - arcade_intro_2
 - final_boss_1_1

--- a/lint/locales/sv.txt
+++ b/lint/locales/sv.txt
@@ -1,4 +1,4 @@
-Translation coverage: 41.80%
+Translation coverage: 263 / 593 required (44.35%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - arcade_intro_2
 - brother

--- a/lint/locales/tr.txt
+++ b/lint/locales/tr.txt
@@ -1,4 +1,4 @@
-Translation coverage: 57.10%
+Translation coverage: 360 / 593 required (60.71%), 2 / 41 optional (4.88%)
 The following keys have extra translations:
 - final_boss_1_1
 - final_boss_1_2


### PR DESCRIPTION
It is not clear what to count and not to count.
Currently the coverage level is computed as the share of non-missing translations among expected translations.